### PR TITLE
fix: wrong scope of rhs in checkedCeilDiv

### DIFF
--- a/src/raydium/cpmm/curve/constantProduct.ts
+++ b/src/raydium/cpmm/curve/constantProduct.ts
@@ -20,7 +20,7 @@ function checkedCeilDiv(dividend: BN, rhs: BN): BN[] {
   if (remainder.gt(ZERO)) {
     quotient = quotient.add(new BN(1));
 
-    let rhs = dividend.div(quotient);
+    rhs = dividend.div(quotient);
     remainder = checkedRem(dividend, quotient);
     if (remainder.gt(ZERO)) {
       rhs = rhs.add(new BN(1));


### PR DESCRIPTION
rhs value is not properly returned as the let moves the rhs changes into a new scope.