### PR TITLE
fix: correct Buffer.from hex string input

### DIFF
--- a/src/raydium/tradeV2/trade.ts
+++ b/src/raydium/tradeV2/trade.ts
@@ -655,7 +655,7 @@ export default class TradeV2 extends ModuleBase {
         decimals: p.mintA.decimals,
         isInitialized: true,
         freezeAuthority: null,
-        tlvData: Buffer.from("0", "hex"),
+        tlvData: Buffer.from("00", "hex"),
         feeConfig: undefined,
       };
 
@@ -668,7 +668,7 @@ export default class TradeV2 extends ModuleBase {
         decimals: p.mintB.decimals,
         isInitialized: true,
         freezeAuthority: null,
-        tlvData: Buffer.from("0", "hex"),
+        tlvData: Buffer.from("00", "hex"),
         feeConfig: undefined,
       };
     });
@@ -691,7 +691,7 @@ export default class TradeV2 extends ModuleBase {
           decimals: p.mintDecimalA,
           isInitialized: true,
           freezeAuthority: null,
-          tlvData: Buffer.from("0", "hex"),
+          tlvData: Buffer.from("00", "hex"),
           feeConfig: undefined,
         };
       } else mintSet.add(mintA); // 2022, need to fetch fee config
@@ -705,7 +705,7 @@ export default class TradeV2 extends ModuleBase {
           decimals: p.mintDecimalB,
           isInitialized: true,
           freezeAuthority: null,
-          tlvData: Buffer.from("0", "hex"),
+          tlvData: Buffer.from("00", "hex"),
           feeConfig: undefined,
         };
       } else mintSet.add(mintB); // 2022, need to fetch fee config


### PR DESCRIPTION
since `@esbuild-plugins/node-globals-polyfill` don't support `Buffer.from("0", "hex")`.

Changed Buffer.from("0", "hex") to Buffer.from("00", "hex") to ensure a valid even-length hex string input. This prevents creation of an empty Buffer and correctly creates a Buffer of length 1 containing 0x00.