### PR TITLE
fix(cpmm-add-liquidity): the deposits will fail in any sol pool if invariant changes

### DIFF
--- a/src/raydium/cpmm/cpmm.ts
+++ b/src/raydium/cpmm/cpmm.ts
@@ -431,6 +431,7 @@ export default class CpmmModule extends ModuleBase {
       liquidity,
       inputAmountFee,
       anotherAmount: _anotherAmount,
+      maxAnotherAmount: _maxAnotherAmount,
     } = computeResult ||
     this.computePairAmount({
       poolInfo: {
@@ -448,6 +449,7 @@ export default class CpmmModule extends ModuleBase {
     });
 
     const anotherAmount = _anotherAmount.amount;
+    const maxAnotherAmount = _maxAnotherAmount.amount;
     const mintAUseSOLBalance = poolInfo.mintA.address === NATIVE_MINT.toString();
     const mintBUseSOLBalance = poolInfo.mintB.address === NATIVE_MINT.toString();
 
@@ -464,7 +466,8 @@ export default class CpmmModule extends ModuleBase {
           mintAUseSOLBalance || (baseIn ? inputAmount : anotherAmount).isZero()
             ? {
                 payer: this.scope.ownerPubKey,
-                amount: baseIn ? inputAmount : anotherAmount,
+                // We take max another amount as this will prevent failure(Insufficient balance error) in case where the invariant changes before the transaction is send.
+                amount: baseIn ? inputAmount : maxAnotherAmount,
               }
             : undefined,
         skipCloseAccount: !mintAUseSOLBalance,


### PR DESCRIPTION
I noticed that in the implementation when converting sol to wsol, we only convert anotherAmount variable, but it is possible that in invariant changes. In that case, if `anotherAmount` is slightly smaller than the amount needed for the deposit, the instruction on the smart contract side will cause failure with the error Insufficient balance.

It is more ideal that in the computePairAmount the slippage is also passed(right now its passed as 0) and then the amount calculate will be more correct.