### PR TITLE
Improved errors when a transaction fails.

### DIFF
--- a/src/common/txTool/txUtils.ts
+++ b/src/common/txTool/txUtils.ts
@@ -61,7 +61,7 @@ export async function confirmTransaction(connection: Connection, txId: string): 
           resolve("");
           return;
         }
-        reject(signatureResult.err.toString());
+        reject(signatureResult.err);
       },
       "confirmed",
     );


### PR DESCRIPTION
When a transaction fails (such as due to insufficient funds), the error that is thrown is just a string of an object. It is unhelpful when catching the error to display a rationale for why it failed.  Instead of throwing a string, we should just throw the actual object, so that people can decide what to do with it themselves.

Scaffold:
```
try {
    ...do swap...
} catch(error) {
    console.log("Caught this error", error);
}
```

Old behavior:
```
...
Caught this error: [object Object]
...
```

New behavior:
```
Caught this error: { InstructionError: [ 2, { Custom: 40 } ] }
```
Which now I can at least know that the transaction is visible on solscan and I can look up the program at instruction index 2 which failed. In this case, it is:

https://github.com/raydium-io/raydium-amm/blob/d10a8e9fab9f7a3d87b4ae3891e3e4c24b75c041/program/src/error.rs#L150