### PR TITLE
feat: add vaults to ComputeClmmPoolInfo type

### DIFF
--- a/src/raydium/clmm/type.ts
+++ b/src/raydium/clmm/type.ts
@@ -146,7 +146,8 @@ export interface ComputeClmmPoolInfo {
   version: 6;
   mintA: ApiV3Token;
   mintB: ApiV3Token;
-
+  vaultA: PublicKey;
+  vaultB: PublicKey;
   ammConfig: ClmmConfigInfo;
   observationId: PublicKey;
   exBitmapAccount: PublicKey;


### PR DESCRIPTION
When looking at the logs we can see that these properties exist on this type and should be able to be used without typescript errors. 

<img width="903" alt="Screenshot 2025-05-23 at 2 08 01 PM" src="https://github.com/user-attachments/assets/2e4e6441-ff3a-491b-be7d-91aeaf663584" />

<img width="1129" alt="Screenshot 2025-05-23 at 1 58 28 PM" src="https://github.com/user-attachments/assets/63337c8c-2104-44e7-a1bf-080cc296fff4" />
