### PR TITLE
fix: check for token2022 when creating transfer instruction for fee

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
-  "name": "@raydium-io/raydium-sdk-v2",
-  "version": "0.2.6-alpha",
+  "name": "@karankurbur/raydium-sdk-v2",
+  "version": "0.3.0",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "description": "An SDK for building applications on top of Raydium.",
   "license": "GPL-3.0",
   "main": "./lib/index.js",
@@ -10,11 +14,7 @@
     "./lib",
     "./src"
   ],
-  "repository": "https://github.com/raydium-io/raydium-sdk-V2",
-  "publicConfig": {
-    "registry": "https://registry.yarnpkg.com",
-    "access": "public"
-  },
+  "repository": "https://github.com/karankurbur/raydium-sdk-v2",
   "keywords": [
     "raydium",
     "solana"

--- a/src/raydium/tradeV2/trade.ts
+++ b/src/raydium/tradeV2/trade.ts
@@ -1,5 +1,10 @@
 import { EpochInfo, PublicKey } from "@solana/web3.js";
-import { createTransferInstruction, TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import {
+  createTransferInstruction,
+  TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
+  createTransferCheckedInstruction,
+} from "@solana/spl-token";
 import BN from "bn.js";
 import Decimal from "decimal.js";
 import { AmmV4Keys, ApiV3Token, ClmmKeys, PoolKeys } from "@/api";
@@ -278,17 +283,30 @@ export default class TradeV2 extends ModuleBase {
 
     if (swapInfo.feeConfig !== undefined) {
       const checkTxBuilder = this.createTxBuilder();
-      checkTxBuilder.addInstruction({
-        instructions: [
-          createTransferInstruction(
+
+      // Use createTransferCheckedInstruction for Token2022, createTransferInstruction for regular tokens
+      const transferInstruction = amountIn.amount.token.isToken2022
+        ? createTransferCheckedInstruction(
+            sourceAcc,
+            amountIn.amount.token.mint, // mint parameter required for checked transfer
+            swapInfo.feeConfig.feeAccount,
+            this.scope.ownerPubKey,
+            swapInfo.feeConfig.feeAmount.toNumber(),
+            amountIn.amount.token.decimals, // decimals parameter required for checked transfer
+            [],
+            TOKEN_2022_PROGRAM_ID,
+          )
+        : createTransferInstruction(
             sourceAcc,
             swapInfo.feeConfig.feeAccount,
             this.scope.ownerPubKey,
             swapInfo.feeConfig.feeAmount.toNumber(),
             [],
-            amountIn.amount.token.isToken2022 ? TOKEN_2022_PROGRAM_ID : TOKEN_PROGRAM_ID,
-          ),
-        ],
+            TOKEN_PROGRAM_ID,
+          );
+
+      checkTxBuilder.addInstruction({
+        instructions: [transferInstruction],
         instructionTypes: [InstructionType.TransferAmount],
       });
       checkTxBuilder.addInstruction(swapIns);
@@ -297,16 +315,7 @@ export default class TradeV2 extends ModuleBase {
         txVersion === TxVersion.V0 ? await checkTxBuilder.sizeCheckBuildV0() : await checkTxBuilder.sizeCheckBuild();
       if (transactions.length < 2) {
         txBuilder.addInstruction({
-          instructions: [
-            createTransferInstruction(
-              sourceAcc,
-              swapInfo.feeConfig.feeAccount,
-              this.scope.ownerPubKey,
-              swapInfo.feeConfig.feeAmount.toNumber(),
-              [],
-              amountIn.amount.token.isToken2022 ? TOKEN_2022_PROGRAM_ID : TOKEN_PROGRAM_ID,
-            ),
-          ],
+          instructions: [transferInstruction],
           instructionTypes: [InstructionType.TransferAmount],
         });
       }


### PR DESCRIPTION
Always assumes SPL token when creating fee token transfer instruction. Add a conditional to check for Token2022