### PR TITLE
fix: jup token list v1 no longer working

### DIFF
--- a/src/api/url.ts
+++ b/src/api/url.ts
@@ -24,7 +24,7 @@ export const API_URLS = {
   TOKEN_LIST: "/mint/list",
   MINT_INFO_ID: "/mint/ids",
 
-  JUP_TOKEN_LIST: "https://lite-api.jup.ag/tokens/v1/tagged/verified",
+  JUP_TOKEN_LIST: "https://lite-api.jup.ag/tokens/v2/tag?query=verified",
   /**
    * poolType: {all, concentrated, standard, allFarm, concentratedFarm, standardFarm}
    * poolSortField: {liquidity | volume_24h / 7d / 30d | fee_24h / 7d / 30d | apr_24h / 7d / 30d}


### PR DESCRIPTION
The token list for v1 has been deprecated few months ago and no raise a 404.