### PR TITLE
fix(clmm): use Decimal for fractional slippage in getAmountsFromLiquidity

### DIFF
--- a/src/raydium/clmm/libraries/pool.ts
+++ b/src/raydium/clmm/libraries/pool.ts
@@ -979,13 +979,13 @@ export class PoolUtils {
     ];
     const [amountSlippageA, amountSlippageB] = [
       getTransferAmountFeeV2(
-        amounts.amountA.muln(coefficientRe),
+        new BN(new Decimal(amounts.amountA.toString()).mul(coefficientRe).toFixed(0)),
         poolInfo.mintA.extensions?.feeConfig,
         epochInfo,
         true,
       ),
       getTransferAmountFeeV2(
-        amounts.amountB.muln(coefficientRe),
+        new BN(new Decimal(amounts.amountB.toString()).mul(coefficientRe).toFixed(0)),
         poolInfo.mintB.extensions?.feeConfig,
         epochInfo,
         true,


### PR DESCRIPTION
### Problem

`PoolUtils.getAmountsFromLiquidity` scales the token amounts by the fractional slippage coefficient using `BN.muln`:

```ts
const coefficientRe = add ? 1 + slippage : 1 - slippage; // fractional, e.g. 1.01 or 0.99
...
amounts.amountA.muln(coefficientRe),
amounts.amountB.muln(coefficientRe),
```

`BN.muln` does not require an integer argument. It multiplies each 26-bit limb by the float and bit-masks the result, so a fractional coefficient silently corrupts the value instead of throwing.

Verified against bn.js 5.2.1 with `amountA = 1_000_000_000`:

| case | coefficient | `muln` (current) | correct |
| --- | --- | --- | --- |
| remove, slippage 0.01 | 0.99 | `932286376` | `990000000` (off by 5.83%) |
| add, slippage 0.01 | 1.01 | `1000604759` | `1010000000` |
| add, slippage 0.005 | 1.005 | `1000302379` | `1005000000` |
| slippage 0 | 1.0 | `1000000000` | `1000000000` (integer coefficient is fine) |

`getAmountsFromLiquidity` is exported via `PoolUtils` (through `clmm/libraries` -> `clmm` -> the package root) and reached by `getLiquidityAmountOutFromAmountIn`, so any `slippage > 0` returns wrong `amountSlippageA`/`amountSlippageB`: remove-liquidity min amounts under-protect against slippage, and add-liquidity max amounts collapse far below the intended tolerance (causing on-chain reverts).

### Summary of changes

Scale through `Decimal` instead of `BN.muln`, matching the sibling `LiquidityMathUtil.getAmountsFromLiquidityWithSlippage`, which already does `new BN(new Decimal(amount).mul(coefficient).toFixed(0))` for the same purpose. `Decimal` and `BN` are already imported in the file.

### Testing

The bn.js repro above returns the corrected `990000000` / `1010000000` after the change, while the integer-coefficient (`slippage 0`) case is unchanged.
